### PR TITLE
@msalazarm fix to build Monero dependencies in the correct order

### DIFF
--- a/scripts/android/build_monero_all.sh
+++ b/scripts/android/build_monero_all.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 ( ./build_iconv.sh && ./build_boost.sh ) &
-(./build_openssl.sh && ./build_unbound.sh) &
+./build_openssl.sh &
 ./build_sodium.sh &
 ./build_zmq.sh &
+wait
+./build_unbound.sh &
 wait
 ./build_monero.sh


### PR DESCRIPTION
Makes sure that the custom-compiled libraries and built in the correct order.  Paired with work ongoing over in https://github.com/sneurlax/stack_wallet/tree/scripts/setup