### PR TITLE
Enable mainnet Monero and Wownero Stack Wallet tests

### DIFF
--- a/cw_monero/lib/api/monero_api.dart
+++ b/cw_monero/lib/api/monero_api.dart
@@ -1,6 +1,26 @@
 import 'dart:ffi';
 import 'dart:io';
 
-final DynamicLibrary moneroApi = Platform.isAndroid || Platform.isLinux
-    ? DynamicLibrary.open("libcw_monero.so")
-    : DynamicLibrary.open("cw_monero.framework/cw_monero");
+DynamicLibrary get moneroApi {
+  if (Platform.environment.containsKey('FLUTTER_TEST')) {
+    // DynamicLibrary.open(
+    //     'scripts/linux/build/jsoncpp/build/src/lib_json/libjsoncpp.so');
+    // DynamicLibrary.open(
+    //     'scripts/linux/build/jsoncpp/build/src/lib_json/libjsoncpp.so.1');
+    // DynamicLibrary.open(
+    //     'scripts/linux/build/jsoncpp/build/src/lib_json/libjsoncpp.so.1.7.4');
+    //
+    // DynamicLibrary.open(
+    //     'scripts/linux/build/libsecret/_build/libsecret/libsecret-1.so');
+    // DynamicLibrary.open(
+    //     'scripts/linux/build/libsecret/_build/libsecret/libsecret-1.so.0');
+    // DynamicLibrary.open(
+    //     'scripts/linux/build/libsecret/_build/libsecret/libsecret-1.so.0.0.0');
+
+    return DynamicLibrary.open(
+        'crypto_plugins/flutter_libmonero/scripts/linux/build/libcw_monero.so');
+  }
+  return Platform.isAndroid || Platform.isLinux
+      ? DynamicLibrary.open("libcw_monero.so")
+      : DynamicLibrary.open("cw_monero.framework/cw_monero");
+}

--- a/lib/core/key_service.dart
+++ b/lib/core/key_service.dart
@@ -6,7 +6,7 @@ import 'package:flutter_libmonero/entities/secret_store_key.dart';
 class KeyService {
   KeyService(this._secureStorage);
 
-  final FlutterSecureStorage _secureStorage;
+  final dynamic _secureStorage;
 
   Future<String> getWalletPassword({String? walletName}) async {
     final key = generateStoreKeyFor(

--- a/lib/core/wallet_creation_service.dart
+++ b/lib/core/wallet_creation_service.dart
@@ -22,7 +22,7 @@ class WalletCreationService {
   }
 
   WalletType type = WalletType.monero;
-  final FlutterSecureStorage? secureStorage;
+  final dynamic secureStorage;
   final SharedPreferences? sharedPreferences;
   final KeyService? keyService;
   WalletService? _service;


### PR DESCRIPTION
Two changes in flutter_libmonero enable Monero mainnet tests for Stack Wallet: @msalazarm's fix for selecting native libraries in certain linux build environments (for both cw_monero and cw_wownero) and changing the type of FlutterSecureStorage to dynamic in two services to allow fake storage adapters to be used for testing. 

TODO: Add relevant flutter_libmonero tests in/on flutter_libmonero itself