### PR TITLE
Fix by @msalazarm to set threads for compilation using nproc instead of a hardcoded 16

### DIFF
--- a/scripts/linux/config.sh
+++ b/scripts/linux/config.sh
@@ -8,7 +8,7 @@ export ANDROID_NDK_HOME=$ANDROID_NDK_ROOT
 export TOOLCHAIN_DIR="${WORKDIR}/toolchain"
 export TOOLCHAIN_BASE_DIR=$TOOLCHAIN_DIR
 export ORIGINAL_PATH=$PATH
-export THREADS=16
+export THREADS=$(nproc)
 export TYPES_OF_BUILD="x86_64"
 
 if [ -z "$IS_ARM" ]; then


### PR DESCRIPTION
Thank you @msalazarm!  This PR just affects `scripts/linux/config.sh`, the other platforms' config files already use this change