### PR TITLE
new clang no like old boost

### DIFF
--- a/scripts/ios/build_boost.sh
+++ b/scripts/ios/build_boost.sh
@@ -13,6 +13,7 @@ echo "============================ Boost ============================"
 echo "Cloning Apple-Boost-BuildScript from - $BOOST_URL"
 git clone -b build $BOOST_URL $BOOST_DIR_PATH
 cd $BOOST_DIR_PATH
+sed -i .bak 's/CXX_FLAGS=""/CXX_FLAGS="-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION -Wno-error=enum-constexpr-conversion"/g' boost.sh
 ./boost.sh -ios \
 	--min-ios-version ${MIN_IOS_VERSION} \
 	--boost-libs "${BOOST_LIBS}" \


### PR DESCRIPTION
for context: https://reviews.llvm.org/D131307
boost mpl has a -1 enum set where the only valid range is [1,3] which used to be a warning, but with new clang its now an error so we cheat at do -Wno-error
Not ideal but if we are changing to use a different monero lib soon(tm) it should be ok...